### PR TITLE
fix: Adjust changelog action reference from local file to common actions repository

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: ./update-changelog
+      - uses: hmcts/cnp-githubactions-library/update-changelog@main
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           version: ${{ needs.draft.outputs.version }}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31414

### Change description

Release drafting now works...
Now fix the change log job which I have inadvertently broken by changing the `uses` to `      - uses: ./update-changelog` instead of repo reference 🤦 
Will update the template in the common repo with this once I confirm this works.

### Testing done

-

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
